### PR TITLE
Add sync manager for automatic data sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ EntityScout Pro is designed for SEO professionals, content marketers, and compet
 - **Interactive Dashboard**: Visual analytics with charts, filters, and historical comparisons
 - **Multi-format Export**: Export analysis results to CSV, JSON, and PDF formats
 - **Historical Tracking**: Save and compare analyses over time
+- **Automatic Sync**: Analyses are synced across devices via Chrome storage
 - **Real-time Progress**: Live updates during content processing
 - **Advanced Filtering**: Sort and filter entities by type, confidence, and relevance
 - **Bulk Analysis**: Process multiple URLs simultaneously (Premium feature)

--- a/background.js
+++ b/background.js
@@ -1,3 +1,5 @@
+importScripts('storagemanager.js', 'syncmanager.js');
+
 let quotaUsage = 0;
 let apiKey = '';
 let isProcessing = false;
@@ -7,10 +9,14 @@ async function init() {
     const result = await chrome.storage.sync.get(['apiKey', 'quotaUsage']);
     apiKey = result.apiKey || '';
     quotaUsage = result.quotaUsage || 0;
-    
+
     if (!apiKey) {
       chrome.action.setBadgeText({ text: '!' });
       chrome.action.setBadgeBackgroundColor({ color: '#ff0000' });
+    }
+
+    if (typeof syncManager !== 'undefined') {
+      await syncManager.init();
     }
   } catch (error) {
     console.error('Initialization error:', error);

--- a/syncmanager.js
+++ b/syncmanager.js
@@ -1,0 +1,56 @@
+class SyncManager {
+  constructor(storageManager) {
+    this.storageManager = storageManager;
+    this.syncKey = 'synced_analyses';
+  }
+
+  async init() {
+    if (!chrome.storage || !chrome.storage.sync || !this.storageManager) {
+      return;
+    }
+
+    chrome.storage.onChanged.addListener(this.handleChange.bind(this));
+    await this.syncFromCloud();
+  }
+
+  async handleChange(changes, areaName) {
+    try {
+      if (areaName === 'local' && changes[this.storageManager.STORAGE_KEYS.ANALYSES]) {
+        await this.syncToCloud();
+      } else if (areaName === 'sync' && changes[this.syncKey]) {
+        await this.syncFromCloud();
+      }
+    } catch (error) {
+      console.error('SyncManager change handling failed:', error);
+    }
+  }
+
+  async syncToCloud() {
+    try {
+      const data = await this.storageManager.exportData();
+      await chrome.storage.sync.set({ [this.syncKey]: data.analyses });
+    } catch (error) {
+      console.error('SyncManager syncToCloud failed:', error);
+    }
+  }
+
+  async syncFromCloud() {
+    try {
+      const result = await chrome.storage.sync.get(this.syncKey);
+      if (result[this.syncKey]) {
+        await this.storageManager.importData({ analyses: result[this.syncKey] });
+      }
+    } catch (error) {
+      console.error('SyncManager syncFromCloud failed:', error);
+    }
+  }
+}
+
+const syncManager = new SyncManager(typeof window !== 'undefined' ? window.storageManager : null);
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = SyncManager;
+} else if (typeof window !== 'undefined') {
+  window.SyncManager = SyncManager;
+  window.syncManager = syncManager;
+}


### PR DESCRIPTION
## Summary
- add `SyncManager` module to sync analysis data via Chrome storage
- load `SyncManager` in `background.js` and initialize on startup
- document new Automatic Sync feature in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686236080970832ea2a64ed31b73fc1e